### PR TITLE
feat: generate ed25519 ssh keys

### DIFF
--- a/cmd/minikube/cmd/cp.go
+++ b/cmd/minikube/cmd/cp.go
@@ -49,9 +49,9 @@ var cpCmd = &cobra.Command{
 	Long: `Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
 Default target node controlplane and If <source node name> is omitted, It will trying to copy from host.
 
-Example Command : "minikube cp a.txt /home/docker/b.txt" +
-                  "minikube cp a.txt minikube-m02:/home/docker/b.txt"
-                  "minikube cp minikube-m01:a.txt minikube-m02:/home/docker/b.txt"`,
+Example Command : "minikube cp a.txt /root/b.txt" +
+                  "minikube cp a.txt minikube-m02:/root/b.txt"
+                  "minikube cp minikube-m01:a.txt minikube-m02:/root/b.txt"`,
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 2 {
 			exit.Message(reason.Usage, `Please specify the path to copy: 
@@ -210,6 +210,6 @@ func validateArgs(src, dst *remotePath) {
 	// if node name not explicitly specified in both of source and target,
 	// consider target node is control-plane for backward compatibility.
 	if src.node == "" && dst.node == "" && !strings.HasPrefix(dst.path, "/") {
-		exit.Message(reason.Usage, `Target <remote file path> must be an absolute Path. Relative Path is not allowed (example: "minikube:/home/docker/copied.txt")`)
+           exit.Message(reason.Usage, `Target <remote file path> must be an absolute Path. Relative Path is not allowed (example: "minikube:/root/copied.txt")`)
 	}
 }

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -51,7 +51,7 @@ const (
 	nineP                     = "9p"
 	defaultMount9PVersion     = "9p2000.L"
 	mount9PVersionDescription = "Specify the 9p version that the mount should use"
-	defaultMountGID           = "docker"
+       defaultMountGID           = "root"
 	mountGIDDescription       = "Default group id used for the mount"
 	defaultMountIP            = ""
 	mountIPDescription        = "Specify the ip that the mount should be setup on"
@@ -62,7 +62,7 @@ const (
 	mountPortDescription      = "Specify the port that the mount should be setup on, where 0 means any free port."
 	defaultMountType          = nineP
 	mountTypeDescription      = "Specify the mount filesystem type (supported types: 9p)"
-	defaultMountUID           = "docker"
+       defaultMountUID           = "root"
 	mountUIDDescription       = "Default user id used for the mount"
 )
 

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -208,7 +208,7 @@ func startKicServiceTunnel(services service.URLs, configName, driverName string)
 			exit.Error(reason.DrvPortForward, "error getting ssh port", err)
 		}
 		sshPort := strconv.Itoa(port)
-		sshKey := filepath.Join(localpath.MiniPath(), "machines", configName, "id_rsa")
+		sshKey := filepath.Join(localpath.MiniPath(), "machines", configName, "id_ed25519")
 
 		serviceTunnel := kic.NewServiceTunnel(sshPort, sshKey, clientset.CoreV1(), serviceURLMode)
 		urls, err := serviceTunnel.Start(svc.Name, namespace)

--- a/cmd/minikube/cmd/ssh-host.go
+++ b/cmd/minikube/cmd/ssh-host.go
@@ -67,7 +67,7 @@ func appendKnownHelper(nodeName string, appendKnown bool) {
 		}
 	}
 
-	scanArgs := []string{"-t", "rsa"}
+	scanArgs := []string{"-t", "ed25519"}
 
 	keys, err := machine.RunSSHHostCommand(co.API, *co.Config, *n, "ssh-keyscan", scanArgs)
 	if err != nil {

--- a/cmd/minikube/cmd/ssh-key.go
+++ b/cmd/minikube/cmd/ssh-key.go
@@ -41,7 +41,7 @@ var sshKeyCmd = &cobra.Command{
 			exit.Error(reason.GuestNodeRetrieve, "retrieving node", err)
 		}
 
-		out.Ln(filepath.Join(localpath.MiniPath(), "machines", config.MachineName(*cc, *n), "id_rsa"))
+		out.Ln(filepath.Join(localpath.MiniPath(), "machines", config.MachineName(*cc, *n), "id_ed25519"))
 	},
 }
 

--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -102,7 +102,7 @@ var tunnelCmd = &cobra.Command{
 				exit.Error(reason.DrvPortForward, "error getting ssh port", err)
 			}
 			sshPort := strconv.Itoa(port)
-			sshKey := filepath.Join(localpath.MiniPath(), "machines", cname, "id_rsa")
+			sshKey := filepath.Join(localpath.MiniPath(), "machines", cname, "id_ed25519")
 
 			outputTunnelStarted()
 			kicSSHTunnel := kic.NewSSHTunnel(ctx, sshPort, sshKey, bindAddress, clientset.CoreV1(), clientset.NetworkingV1())

--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -151,9 +151,9 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
         mv /userdata.tar /var/lib/boot2docker/
     fi
 
-    tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/
-    chown -R docker:docker /home/docker/.ssh
-    rm -f '/home/docker/boot2docker, please format-me'
+    tar xf /var/lib/boot2docker/userdata.tar -C /root/
+    chown -R root:root /root/.ssh
+    rm -f '/root/boot2docker, please format-me'
 
     mkdir -p /mnt/$PARTNAME/var/lib/minikube
     mkdir /var/lib/minikube

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -262,6 +262,8 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER docker
 RUN mkdir /home/docker/.ssh
 USER root
+# prepare root ssh directory for minikube access
+RUN mkdir /root/.ssh
 # kind base-image entry-point expects a "kind" folder for product_name,product_uuid
 # https://github.com/kubernetes-sigs/kind/blob/master/images/base/files/usr/local/bin/entrypoint
 RUN mkdir -p /kind

--- a/pkg/drivers/common/common.go
+++ b/pkg/drivers/common/common.go
@@ -31,10 +31,10 @@ import (
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/mcnutils"
-	"github.com/docker/machine/libmachine/ssh"
 	"github.com/pkg/errors"
 
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/sshutil"
 	"k8s.io/minikube/pkg/util"
 )
 
@@ -149,7 +149,7 @@ func MakeDiskImage(d *drivers.BaseDriver, boot2dockerURL string, diskSize int) e
 
 	keyPath := d.GetSSHKeyPath()
 	klog.Infof("Creating ssh key: %s...", keyPath)
-	if err := ssh.GenerateSSHKey(keyPath); err != nil {
+	if err := sshutil.GenerateSSHKey(keyPath); err != nil {
 		return errors.Wrap(err, "generate ssh key")
 	}
 

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -71,7 +71,7 @@ type Driver struct {
 func NewDriver(_, _ string) *Driver {
 	return &Driver{
 		BaseDriver: &drivers.BaseDriver{
-			SSHUser: "docker",
+                       SSHUser: "root",
 		},
 		CommonDriver: &common.CommonDriver{},
 	}

--- a/pkg/drivers/krunkit/krunkit.go
+++ b/pkg/drivers/krunkit/krunkit.go
@@ -36,7 +36,6 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnutils"
-	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 
@@ -49,6 +48,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/process"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/sshutil"
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
@@ -60,7 +60,7 @@ const (
 	logFileName    = "krunkit.log"
 	serialFileName = "serial.log"
 	logLevelInfo   = "3"
-	defaultSSHUser = "docker"
+        defaultSSHUser = "root"
 )
 
 // Driver is the machine driver for krunkit.
@@ -109,7 +109,7 @@ func (d *Driver) GetSSHHostname() (string, error) {
 }
 
 func (d *Driver) GetSSHKeyPath() string {
-	return d.ResolveStorePath("id_rsa")
+	return d.ResolveStorePath("id_ed25519")
 }
 
 func (d *Driver) GetSSHPort() (int, error) {
@@ -169,7 +169,7 @@ func (d *Driver) Create() error {
 	}
 
 	log.Info("Creating SSH key...")
-	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+	if err := sshutil.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return err
 	}
 
@@ -208,7 +208,7 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	log.Infof("Waiting for VM to start (ssh -p %d docker@%s)...", d.SSHPort, d.IPAddress)
+       log.Infof("Waiting for VM to start (ssh -p %d root@%s)...", d.SSHPort, d.IPAddress)
 	if err := WaitForTCPWithDelay(fmt.Sprintf("%s:%d", d.IPAddress, d.SSHPort), time.Second); err != nil {
 		return err
 	}

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -108,7 +108,7 @@ func NewDriver(hostName, storePath string) *Driver {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: hostName,
 			StorePath:   storePath,
-			SSHUser:     "docker",
+                       SSHUser:     "root",
 		},
 		CommonDriver:   &common.CommonDriver{},
 		PrivateNetwork: defaultPrivateNetworkName,

--- a/pkg/minikube/cluster/mount_test.go
+++ b/pkg/minikube/cluster/mount_test.go
@@ -41,8 +41,8 @@ func TestMntCmd(t *testing.T) {
 			name:   "named uid",
 			source: "src",
 			target: "target",
-			cfg:    &MountConfig{Type: "9p", UID: "docker", GID: "docker"},
-			want:   "sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker),trans=tcp src target",
+                       cfg:    &MountConfig{Type: "9p", UID: "root", GID: "root"},
+                       want:   "sudo mount -t 9p -o dfltgid=$(grep ^root: /etc/group | cut -d: -f3),dfltuid=$(id -u root),trans=tcp src target",
 		},
 		{
 			name:   "everything",

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -34,9 +34,9 @@ const vboxConfig = `
 {
         "IPAddress": "192.168.59.101",
         "MachineName": "minikube",
-        "SSHUser": "docker",
+       "SSHUser": "root",
         "SSHPort": 33627,
-        "SSHKeyPath": "/home/sundarp/.minikube/machines/minikube/id_rsa",
+        "SSHKeyPath": "/home/sundarp/.minikube/machines/minikube/id_ed25519",
         "StorePath": "/home/sundarp/.minikube",
         "SwarmMaster": false,
         "SwarmHost": "",

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -963,7 +963,7 @@ var guestIssues = []match{
 			Advice:   "Ensure the tmp directory path is writable to the current user.",
 			Issues:   []int{10772},
 		},
-		// copying pub key: docker copy /var/folders/s8/wxxccj3x7mncysv_zzm5w_r400h78j/T/tmpf-memory-asset645583169 into minikube:/home/docker/.ssh/authorized_keys, output: lstat /private/var/folders/s8/wxxccj3x7mncysv_zzm5w_r400h78j/T/tmpf-memory-asset645583169: no such file or directory
+           // copying pub key: docker copy /var/folders/s8/wxxccj3x7mncysv_zzm5w_r400h78j/T/tmpf-memory-asset645583169 into minikube:/root/.ssh/authorized_keys, output: lstat /private/var/folders/s8/wxxccj3x7mncysv_zzm5w_r400h78j/T/tmpf-memory-asset645583169: no such file or directory
 		Regexp: re(`copying pub key:*.* no such file or directory`),
 	},
 	{
@@ -1059,7 +1059,7 @@ var guestIssues = []match{
 			Advice:   "minikube is missing files relating to your guest environment. This can be fixed by running 'minikube delete'",
 			Issues:   []int{9130},
 		},
-		Regexp: re(`id_rsa: no such file or directory`),
+		Regexp: re(`id_ed25519: no such file or directory`),
 	},
 	{
 		Kind: Kind{

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -69,7 +69,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: config.MachineName(cfg, n),
 			StorePath:   localpath.MiniPath(),
-			SSHUser:     "docker",
+                   SSHUser:     "root",
 		},
 		Boot2DockerURL: download.LocalISOResource(cfg.MinikubeISO),
 		DiskSize:       cfg.DiskSize,

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -76,7 +76,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 	d.MemSize = cfg.Memory
 	d.CPU = cfg.CPUs
 	d.DiskSize = cfg.DiskSize
-	d.SSHUser = "docker"
+    d.SSHUser = "root"
 	d.DisableDynamicMemory = true // default to disable dynamic memory as minikube is unlikely to work properly with dynamic memory
 	return d, nil
 }

--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -75,7 +75,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: machineName,
 			StorePath:   storePath,
-			SSHUser:     "docker",
+                   SSHUser:     "root",
 		},
 		Boot2DockerURL: download.LocalISOResource(cfg.MinikubeISO),
 		DiskSize:       cfg.DiskSize,

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -80,7 +80,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: name,
 			StorePath:   localpath.MiniPath(),
-			SSHUser:     "docker",
+                   SSHUser:     "root",
 		},
 		Memory:         cc.Memory,
 		CPU:            cc.CPUs,

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -167,7 +167,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: name,
 			StorePath:   localpath.MiniPath(),
-			SSHUser:     "docker",
+                   SSHUser:     "root",
 		},
 		Boot2DockerURL:        download.LocalISOResource(cc.MinikubeISO),
 		DiskSize:              cc.DiskSize,

--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -98,7 +98,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: machineName,
 			StorePath:   storePath,
-			SSHUser:     "docker",
+                   SSHUser:     "root",
 		},
 		Boot2DockerURL: download.LocalISOResource(cfg.MinikubeISO),
 		DiskSize:       cfg.DiskSize,

--- a/pkg/minikube/sshutil/key.go
+++ b/pkg/minikube/sshutil/key.go
@@ -1,0 +1,47 @@
+package sshutil
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// GenerateSSHKey generates an ed25519 SSH key pair at the provided path.
+// The public key is written to the same location with a ".pub" suffix.
+func GenerateSSHKey(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("desired directory for SSH keys does not exist: %w", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("error generating key pair: %w", err)
+	}
+
+	pubKey, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return fmt.Errorf("error creating public key: %w", err)
+	}
+
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return fmt.Errorf("error marshalling private key: %w", err)
+	}
+
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		return fmt.Errorf("error writing private key: %w", err)
+	}
+
+	pubPath := fmt.Sprintf("%s.pub", path)
+	if err := os.WriteFile(pubPath, ssh.MarshalAuthorizedKey(pubKey), 0o644); err != nil {
+		return fmt.Errorf("error writing public key: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -42,7 +42,7 @@ func NewSSHClient(d drivers.Driver) (*ssh.Client, error) {
 		return nil, errors.Wrap(err, "Error creating new ssh host from driver")
 
 	}
-	defaultKeyPath := filepath.Join(homedir.HomeDir(), ".ssh", "id_rsa")
+	defaultKeyPath := filepath.Join(homedir.HomeDir(), ".ssh", "id_ed25519")
 	auth := &machinessh.Auth{}
 	if h.SSHKeyPath != "" {
 		auth.Keys = []string{h.SSHKeyPath}

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -49,7 +49,7 @@ func createSSHConn(name, sshPort, sshKey, bindAddress string, resourcePorts []in
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "IdentitiesOnly=yes",
 		"-N",
-		"docker@127.0.0.1",
+               "root@127.0.0.1",
 		"-p", sshPort,
 		"-i", sshKey,
 	}
@@ -122,7 +122,7 @@ func createSSHConnWithRandomPorts(name, sshPort, sshKey string, svc *v1.Service)
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "IdentitiesOnly=yes",
 		"-N",
-		"docker@127.0.0.1",
+               "root@127.0.0.1",
 		"-p", sshPort,
 		"-i", sshKey,
 	}

--- a/site/content/en/docs/commands/cp.md
+++ b/site/content/en/docs/commands/cp.md
@@ -14,9 +14,9 @@ Copy the specified file into minikube
 Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
 Default target node controlplane and If <source node name> is omitted, It will trying to copy from host.
 
-Example Command : "minikube cp a.txt /home/docker/b.txt" +
-                  "minikube cp a.txt minikube-m02:/home/docker/b.txt"
-                  "minikube cp minikube-m01:a.txt minikube-m02:/home/docker/b.txt"
+Example Command : "minikube cp a.txt /root/b.txt" +
+                  "minikube cp a.txt minikube-m02:/root/b.txt"
+                  "minikube cp minikube-m01:a.txt minikube-m02:/root/b.txt"
 
 ```shell
 minikube cp <source node name>:<source file path> <target node name>:<target file absolute path> [flags]

--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -80,8 +80,8 @@ Services of type `NodePort` can be exposed via the `minikube service <service-na
     Check ssh tunnel in another terminal
 
     ```shell
-    $ ps -ef | grep docker@127.0.0.1
-    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -N docker@127.0.0.1 -p 55972 -i /Users/FOO/.minikube/machines/minikube/id_rsa -L TUNNEL_PORT:CLUSTER_IP:TARGET_PORT
+    $ ps -ef | grep root@127.0.0.1
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -N root@127.0.0.1 -p 55972 -i /Users/FOO/.minikube/machines/minikube/id_ed25519 -L TUNNEL_PORT:CLUSTER_IP:TARGET_PORT
     ```
 
 5. Try in your browser

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -328,10 +328,10 @@ In order to access containerd, you need to log in as `root`.
 This requires adding the ssh key to `/root/authorized_keys`..
 
 ```console
-docker@minikube:~$ sudo mkdir /root/.ssh
-docker@minikube:~$ sudo chmod 700 /root/.ssh
-docker@minikube:~$ sudo cp .ssh/authorized_keys /root/.ssh/authorized_keys
-docker@minikube:~$ sudo chmod 600 /root/.ssh
+root@minikube:~# mkdir -p /root/.ssh
+root@minikube:~# chmod 700 /root/.ssh
+root@minikube:~# cp .ssh/authorized_keys /root/.ssh/authorized_keys
+root@minikube:~# chmod 600 /root/.ssh/authorized_keys
 ```
 
 Note the flags that are needed for the `ssh` command.
@@ -360,16 +360,16 @@ Images in "k8s.io" namespace are accessible to kubernetes cluster.
 Start the BuildKit daemon, using the containerd backend.
 
 ```console
-docker@minikube:~$ sudo -b buildkitd --oci-worker=false --containerd-worker=true --containerd-worker-namespace=k8s.io
+root@minikube:~# buildkitd --oci-worker=false --containerd-worker=true --containerd-worker-namespace=k8s.io &
 ```
 
 Make the BuildKit socket accessible to the regular user.
 
 ```console
-docker@minikube:~$ sudo groupadd buildkit
-docker@minikube:~$ sudo chgrp -R buildkit /run/buildkit
-docker@minikube:~$ sudo usermod -aG buildkit $USER
-docker@minikube:~$ exit
+root@minikube:~# groupadd buildkit
+root@minikube:~# chgrp -R buildkit /run/buildkit
+root@minikube:~# usermod -aG buildkit $USER
+root@minikube:~# exit
 ```
 
 Note the flags that are needed for the `ssh` command.

--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -33,7 +33,7 @@ $ minikube addons enable registry-creds
 
 For additional information on private container registries, see [this page](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
-We recommend you use _ImagePullSecrets_, but if you would like to configure access on the minikube VM you can place the `.dockercfg` in the `/home/docker` directory or the `config.json` in the `/var/lib/kubelet` directory. Make sure to restart your kubelet (for kubeadm) process with `sudo systemctl restart kubelet`.
+We recommend you use _ImagePullSecrets_, but if you would like to configure access on the minikube VM you can place the `.dockercfg` in the `/root` directory or the `config.json` in the `/var/lib/kubelet` directory. Make sure to restart your kubelet (for kubeadm) process with `sudo systemctl restart kubelet`.
 
 ## Enabling Insecure Registries
 

--- a/test/integration/ha_test.go
+++ b/test/integration/ha_test.go
@@ -353,7 +353,7 @@ func validateHACopyFile(ctx context.Context, t *testing.T, profile string) {
 			if n.Name == n2.Name {
 				continue
 			}
-			fp := path.Join("/home/docker", fmt.Sprintf("cp-test_%s_%s.txt", n.Name, n2.Name))
+                   fp := path.Join("/root", fmt.Sprintf("cp-test_%s_%s.txt", n.Name, n2.Name))
 			testCpCmd(ctx, t, profile, n.Name, dstPath, n2.Name, fp)
 		}
 	}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -530,7 +530,7 @@ func killProcessFamily(t *testing.T, pid int) {
 
 // cpTestMinikubePath is where the test file will be located in the Minikube instance
 func cpTestMinikubePath() string {
-	return "/home/docker/cp-test.txt"
+    return "/root/cp-test.txt"
 }
 
 // cpTestLocalPath is where the test file located in host os

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -209,7 +209,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 			if n.Name == n2.Name {
 				continue
 			}
-			fp := path.Join("/home/docker", fmt.Sprintf("cp-test_%s_%s.txt", n.Name, n2.Name))
+                   fp := path.Join("/root", fmt.Sprintf("cp-test_%s_%s.txt", n.Name, n2.Name))
 			testCpCmd(ctx, t, profile, n.Name, dstPath, n2.Name, fp)
 		}
 	}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -454,12 +454,12 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 // Remove container-specific prefixes for naming consistency
 // for example in `docker` runtime we get this:
 //
-//		$ docker@minikube:~$ sudo crictl images -o json | grep dash
+//		$ root@minikube:~# crictl images -o json | grep dash
 //	         "kubernetesui/dashboard:vX.X.X"
 //
 // but for 'containerd' we get full name
 //
-//			$ docker@minikube:~$  sudo crictl images -o json | grep dash
+//			$ root@minikube:~# crictl images -o json | grep dash
 //	       	 "docker.io/kubernetesui/dashboard:vX.X.X"
 func trimImageName(name string) string {
 	name = strings.TrimPrefix(name, "docker.io/")


### PR DESCRIPTION
## Summary
- generate ed25519 ssh key pairs for nodes
- default to root ssh user and paths, updating drivers and docs

## Testing
- `go test ./cmd/... ./pkg/...` *(hangs; terminated with no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c3151a43f4832fbb3796369f23cd69